### PR TITLE
hydra: pass --indirect to work on older Nix's

### DIFF
--- a/src/dispatch_hydra.rs
+++ b/src/dispatch_hydra.rs
@@ -31,7 +31,7 @@ pub async fn serve_hydra(
         .buildoutputs
         .get("out")
         .ok_or_else(|| {
-            warn!("No out for job {:?}", &job_name);
+            warn!("No out for job {:?}. Got: {:?}", &job_name, job);
             reject::not_found()
         })?
         .path;
@@ -59,7 +59,7 @@ pub async fn serve_hydra(
             )
             .body(String::new()))
     } else {
-        warn!("No out for job {:?}", &job_name);
+        warn!("Failed to realize output {} for {:?}", &output, &job_name);
         Err(reject::not_found())
     }
 }

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -15,6 +15,7 @@ pub async fn realize_path(name: String, path: &str, gc_root: &Path) -> io::Resul
         .arg(path)
         .arg("--add-root")
         .arg(&symlink)
+        .arg("--indirect")
         .status()
         .await?;
 


### PR DESCRIPTION
nix-store --realise used to require --indirect to make a GC root anywhere:

```
Jan 05 17:24:44 netboot-springboard nix-netboot-serve[2317232]: error: path '/var/cache/nix-netboot-serve/gc-roots/01ad16e6.packethost.net-nixos-install-equinix-metal-prs-pr-36-small' is not a valid garbage collector root; it's not in the directory '/nix/var/nix/gcroots'
Jan 05 17:24:44 netboot-springboard nix-netboot-serve[2314216]:  WARN  nix_netboot_serve::dispatch_hydra > Failed to realize output /nix/store/mm5614whs2i7x6vl98q1k7nzx3bbpp33-nixos-system-nixos-21.11pre-git for "small"
```