### PR TITLE
dispatch: support passing further kernel cmdline arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,6 +669,7 @@ dependencies = [
  "reqwest",
  "rlimit",
  "serde",
+ "serde_urlencoded",
  "structopt",
  "tempfile",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ pretty_env_logger = "0.4.0"
 reqwest = { version = "0.11.4", features = [ "json" ] }
 rlimit = "0.6.2"
 serde = { version = "1.0.130", features = ["derive"] }
+serde_urlencoded = "0.7.0"
 structopt = { version = "0.3" }
 tempfile = "3.2.0"
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -159,9 +159,10 @@ on a single closure involves recreating the CPIO and recompressing for
 every store path every time. This can add several minutes to cycle
 time.
 
-## Other APIs
+## Other API Information
 
 * Get the size of the initrd: `HEAD /boot/PATH/initrd`
+* Pass additional kernel commandline arguments: `/dispatch/...?cmdline_prefix_args=...&cmdline_suffix_args=...`
 
 ## Caveats
 

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1,20 +1,33 @@
 use std::ffi::OsString;
 use std::path::Path;
 
+use serde::{Deserialize, Serialize};
 use warp::reject;
 use warp::Rejection;
 
-pub fn redirect_symlink_to_boot(symlink: &Path) -> Result<OsString, Rejection> {
+#[derive(Deserialize, Serialize, Debug)]
+pub struct NetbootIpxeTuning {
+    pub cmdline_prefix_args: Option<String>,
+    pub cmdline_suffix_args: Option<String>,
+}
+
+pub fn redirect_symlink_to_boot(
+    symlink: &Path,
+    tuning: NetbootIpxeTuning,
+) -> Result<OsString, Rejection> {
     let path = symlink.read_link().map_err(|e| {
         warn!("Reading the link {:?} failed with: {:?}", symlink, e);
         reject::not_found()
     })?;
 
     trace!("Resolved symlink {:?} to {:?}", symlink, path);
-    redirect_to_boot_store_path(&path)
+    redirect_to_boot_store_path(&path, tuning)
 }
 
-pub fn redirect_to_boot_store_path(path: &Path) -> Result<OsString, Rejection> {
+pub fn redirect_to_boot_store_path(
+    path: &Path,
+    tuning: NetbootIpxeTuning,
+) -> Result<OsString, Rejection> {
     if !path.exists() {
         warn!("Path does not exist: {:?}", &path);
         return Err(reject::not_found());
@@ -23,7 +36,16 @@ pub fn redirect_to_boot_store_path(path: &Path) -> Result<OsString, Rejection> {
     if let Some(std::path::Component::Normal(pathname)) = path.components().last() {
         let mut location = OsString::from("/boot/");
         location.push(pathname);
-        location.push("/netboot.ipxe");
+        location.push(format!(
+            "/netboot.ipxe?{}",
+            serde_urlencoded::to_string(&tuning).map_err(|e| {
+                warn!(
+                    "failed to urlencode these tuning parameters: {:?}, err: {}",
+                    tuning, e
+                );
+                reject::not_found()
+            })?
+        ));
 
         return Ok(location);
     } else {

--- a/src/dispatch_configuration.rs
+++ b/src/dispatch_configuration.rs
@@ -5,11 +5,12 @@ use tokio::process::Command;
 use warp::reject;
 use warp::Rejection;
 
-use crate::dispatch::redirect_symlink_to_boot;
+use crate::dispatch::{redirect_symlink_to_boot, NetbootIpxeTuning};
 use crate::webservercontext::{feature_disabled, server_error, WebserverContext};
 
 pub async fn serve_configuration(
     name: String,
+    tuning: NetbootIpxeTuning,
     context: WebserverContext,
 ) -> Result<impl warp::Reply, Rejection> {
     let config = context
@@ -63,6 +64,9 @@ chain /dispatch/configuration/{}",
 
     Ok(Builder::new()
         .status(302)
-        .header("Location", redirect_symlink_to_boot(&symlink)?.as_bytes())
+        .header(
+            "Location",
+            redirect_symlink_to_boot(&symlink, tuning)?.as_bytes(),
+        )
         .body(String::new()))
 }

--- a/src/dispatch_hydra.rs
+++ b/src/dispatch_hydra.rs
@@ -5,7 +5,7 @@ use http::response::Builder;
 use warp::reject;
 use warp::Rejection;
 
-use crate::dispatch::redirect_to_boot_store_path;
+use crate::dispatch::{redirect_to_boot_store_path, NetbootIpxeTuning};
 use crate::hydra;
 use crate::nix::realize_path;
 use crate::webservercontext::{server_error, WebserverContext};
@@ -15,6 +15,7 @@ pub async fn serve_hydra(
     project: String,
     jobset: String,
     job_name: String,
+    tuning: NetbootIpxeTuning,
     context: WebserverContext,
 ) -> Result<impl warp::Reply, Rejection> {
     let job = hydra::get_latest_job(&server, &project, &jobset, &job_name)
@@ -55,7 +56,7 @@ pub async fn serve_hydra(
             .status(302)
             .header(
                 "Location",
-                redirect_to_boot_store_path(Path::new(&output))?.as_bytes(),
+                redirect_to_boot_store_path(Path::new(&output), tuning)?.as_bytes(),
             )
             .body(String::new()))
     } else {

--- a/src/dispatch_profile.rs
+++ b/src/dispatch_profile.rs
@@ -3,11 +3,12 @@ use std::os::unix::ffi::OsStrExt;
 use http::response::Builder;
 use warp::Rejection;
 
-use crate::dispatch::redirect_symlink_to_boot;
+use crate::dispatch::{redirect_symlink_to_boot, NetbootIpxeTuning};
 use crate::webservercontext::{feature_disabled, WebserverContext};
 
 pub async fn serve_profile(
     name: String,
+    tuning: NetbootIpxeTuning,
     context: WebserverContext,
 ) -> Result<impl warp::Reply, Rejection> {
     let symlink = context
@@ -18,6 +19,9 @@ pub async fn serve_profile(
 
     Ok(Builder::new()
         .status(302)
-        .header("Location", redirect_symlink_to_boot(&symlink)?.as_bytes())
+        .header(
+            "Location",
+            redirect_symlink_to_boot(&symlink, tuning)?.as_bytes(),
+        )
         .body(String::new()))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,15 +56,20 @@ async fn main() {
 
     let root = warp::path::end().map(|| "nix-netboot-serve");
     let profile = warp::path!("dispatch" / "profile" / String)
+        .and(warp::query::<dispatch::NetbootIpxeTuning>())
         .and(with_context(webserver.clone()))
         .and_then(serve_profile);
     let configuration = warp::path!("dispatch" / "configuration" / String)
+        .and(warp::query::<dispatch::NetbootIpxeTuning>())
         .and(with_context(webserver.clone()))
         .and_then(serve_configuration);
     let hydra = warp::path!("dispatch" / "hydra" / String / String / String / String)
+        .and(warp::query::<dispatch::NetbootIpxeTuning>())
         .and(with_context(webserver.clone()))
         .and_then(serve_hydra);
-    let ipxe = warp::path!("boot" / String / "netboot.ipxe").and_then(serve_ipxe);
+    let ipxe = warp::path!("boot" / String / "netboot.ipxe")
+        .and(warp::query::<dispatch::NetbootIpxeTuning>())
+        .and_then(serve_ipxe);
     let initrd = warp::path!("boot" / String / "initrd")
         .and(with_context(webserver.clone()))
         .and_then(serve_initrd);


### PR DESCRIPTION
Passing cmdline_prefix_args and/or cmdline_suffix_args to
any dispatcher as query parameters will allow the caller
to prefix / suffix kernel cmdline arguments in addition
to the arguments defined by the system.

For example: /dispatch/profile/system?cmdline_suffix_args=loglevel%3D7

Use case A: passing in dynamically generated password hashes.

Use case B: passing in a Vault AppRole Role ID, while passing
the response-wrapped Secret ID through some other mechanism,
like a metadata API service.